### PR TITLE
Fix: Support new hf CLI alongside legacy huggingface-cli

### DIFF
--- a/scripts/01_reshard_nvfp4.sh
+++ b/scripts/01_reshard_nvfp4.sh
@@ -30,10 +30,21 @@ echo ""
 
 mkdir -p "$SOURCE_DIR"
 
+
+# find the Hugging Face CLI cmd
+if command -v hf &> /dev/null; then
+    HF_AUTH_CMD="hf auth"
+elif command -v huggingface-cli &> /dev/null; then
+    HF_AUTH_CMD="huggingface-cli"
+else
+    echo "ERROR: HuggingFace CLI is not installed."
+    echo "Please install it first."
+    exit 1
+fi
 # Check HuggingFace auth
-if ! huggingface-cli whoami &>/dev/null; then
+if ! $HF_AUTH_CMD whoami &>/dev/null; then
     echo "ERROR: Not authenticated with HuggingFace."
-    echo "Run: huggingface-cli login"
+    echo "Run: $HF_AUTH_CMD login"
     exit 1
 fi
 


### PR DESCRIPTION
### Description
With recent updates to `huggingface_hub` (v1.0.0+), the legacy `huggingface-cli` command is being deprecated and replaced by the newer, shorter `hf` command. 

Currently, the script hardcodes `huggingface-cli` for authentication checks. This causes failures for users who have freshly installed the latest version of the Hugging Face CLI via `pipx` or `pip`, as their system path only contains the `hf` executable.

### Changes Proposed
* Implemented dynamic CLI command detection using `command -v`.
* The script now gracefully checks for the existence of `hf` first, and falls back to `huggingface-cli` to maintain backward compatibility for older installations.
* Updated the error message to dynamically display the correct login command (`$HF_CMD login`) based on the user's specific environment.

### Code Snippet Updated
Replaced the static check:
```bash
if ! huggingface-cli whoami &>/dev/null; then`
```
With a dynamic check:

```bash
if command -v hf &> /dev/null; then
    HF_CMD="hf auth"
elif command -v huggingface-cli &> /dev/null; then
    HF_CMD="huggingface-cli"
else
    echo "ERROR: HuggingFace CLI is not installed."
    exit 1
fi

if ! $HF_CMD whoami &>/dev/null; then
```

